### PR TITLE
Stop creating .deps during the build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,7 +55,6 @@ $(PREFIX1).automorf.bin: $(BASENAME).$(LANG1).dix
 	lt-comp lr $(BASENAME).$(LANG1).dix $@
 
 $(PREFIX1).autobil.bin: $(BASENAME).$(PREFIX1).dix
-	if [ ! -d .deps ]; then mkdir .deps; fi
 	apertium-validate-dictionary $(BASENAME).$(PREFIX1).dix
 	lt-comp lr $(BASENAME).$(PREFIX1).dix $@
 
@@ -94,7 +93,6 @@ $(PREFIX2).automorf.bin: $(BASENAME).$(LANG2).dix
 	lt-comp lr $(BASENAME).$(LANG2).dix $@
 
 $(PREFIX2).autobil.bin: $(BASENAME).$(PREFIX1).dix
-	if [ ! -d .deps ]; then mkdir .deps; fi
 	apertium-validate-dictionary $(BASENAME).$(PREFIX1).dix
 	lt-comp rl $(BASENAME).$(PREFIX1).dix $@
 


### PR DESCRIPTION
.deps is no longer used since commit fe5619f0

This also fixes #1.